### PR TITLE
Add "Meeting Attendance Hours" report type option

### DIFF
--- a/report.php
+++ b/report.php
@@ -149,6 +149,7 @@
                 <option value = "total_vol_hours">Total Volunteer Hours</option>
                 <option value = "indiv_vol_hours">Individual Volunteer Hours</option>
                 <option value = "top_perform">Top Performers</option>
+                <option value = "meeting_hours">Meeting Attendance Hours</option>
             </select>
 	</div>
 	<br>


### PR DESCRIPTION
This adds an option in report.php to create board member meeting attendance reports.  
The option can be selected, but the functionality is not yet implemented.  
Creating other types of reports still works.